### PR TITLE
Add ability to set acronym "title" inside data-attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ typings/
 
 # Other
 dist/
+.idea

--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ plugins: [
 
 ## Options
 
-| Name       | Default | Description                                                     |
-| ---------- | ------- | --------------------------------------------------------------- |
-| `acronyms` |         | Object containing keys for acronyms and values for descriptions |
+| Name            | Default | Description                                                     |
+| --------------- | ------- | --------------------------------------------------------------- |
+| `acronyms`      |         | Object containing keys for acronyms and values for descriptions |
+| `dataAttribute` | false   | Set acronyms description inside `data-title` attribute          |
 
 ## Usage in Markdown
 
@@ -56,6 +57,12 @@ Given the configuration presented above and this small markdown snippet, the ren
 
 ```html
 <p>My site uses <abbr title="Hypertext Markup Language">HTML</abbr> and <abbr title="Cascading Style Sheets">CSS</abbr>!</p>
+```
+
+If `dataAttribute = true`
+
+```html
+<p>My site uses <abbr data-title="Hypertext Markup Language">HTML</abbr> and <abbr data-title="Cascading Style Sheets">CSS</abbr>!</p>
 ```
 
 ## Styling
@@ -80,6 +87,37 @@ export default props => (
     <main {...props} />
   </MDXProvider>
 );
+```
+
+For styling with property `dataAttribute = true` you can use next styles:
+
+```css
+[data-title] {
+  position: relative;
+}
+
+[data-title]:hover:after {
+  opacity: 1;
+  transition: all 0.1s ease 0.5s;
+  visibility: visible;
+}
+
+[data-title]:after {
+  content: attr(data-title);
+  background-color: #030e2f;
+  color: lightgrey;
+  font-size: 0.75em;
+  position: absolute;
+  padding: 2px 5px;
+  top: -125%;
+  left: -50%;
+  white-space: nowrap;
+  box-shadow: 1px 1px 3px #222;
+  opacity: 0;
+  border: 1px solid #111;
+  z-index: 99999;
+  visibility: hidden;
+}
 ```
 
 ## License

--- a/lib/__tests__/__snapshots__/index.test.ts.snap
+++ b/lib/__tests__/__snapshots__/index.test.ts.snap
@@ -175,3 +175,53 @@ Object {
   "type": "root",
 }
 `;
+
+exports[`gatsby-remark-acronyms should render acronym inside data-attribute if it parameter was set in options 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "I like ",
+        },
+        Object {
+          "type": "html",
+          "value": "<abbr data-title=\\"Hypertext Markup Language\\">HTML</abbr>",
+        },
+        Object {
+          "type": "text",
+          "value": "!",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 13,
+          "line": 1,
+          "offset": 12,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 13,
+      "line": 1,
+      "offset": 12,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;

--- a/lib/__tests__/index.test.ts
+++ b/lib/__tests__/index.test.ts
@@ -35,6 +35,27 @@ describe('gatsby-remark-acronyms', () => {
     expect(transformed).toMatchSnapshot();
   });
 
+  it('should render acronym inside data-attribute if it parameter was set in options', () => {
+    const markdownAST = remark.parse('I like HTML!');
+    const settings = {
+      ...pluginSettings,
+      dataAttribute: true,
+    };
+    const transformed = plugin({ markdownAST }, settings);
+
+    let count = 0;
+
+    visit(transformed, 'html', node => {
+      if (node.value === '<abbr data-title="Hypertext Markup Language">HTML</abbr>') {
+        count++;
+      }
+    });
+
+    expect(count).toEqual(1);
+
+    expect(transformed).toMatchSnapshot();
+  });
+
   it('acronyms are case sensitive', () => {
     const markdownAST = remark.parse('I like Html!');
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,13 +6,14 @@ type GatsbyRemarkPluginParameters = {
 };
 
 type PluginOptions = {
+  dataAttribute?: boolean;
   acronyms: {
     [key: string]: string;
   };
 };
 
 const Plugin = ({ markdownAST }: GatsbyRemarkPluginParameters, pluginOptions = {} as PluginOptions): Node => {
-  const { acronyms } = pluginOptions;
+  const { acronyms, dataAttribute } = pluginOptions;
 
   if (!acronyms) return markdownAST;
 
@@ -23,15 +24,19 @@ const Plugin = ({ markdownAST }: GatsbyRemarkPluginParameters, pluginOptions = {
       const newNodes = node.value.split(acronymsRegExp).map(value => {
         const acronymTitle = acronyms[value];
 
-        return acronymTitle
-          ? {
-              type: 'html',
-              value: `<abbr title="${acronymTitle}">${value}</abbr>`,
-            }
-          : {
-              type: 'text',
-              value,
-            };
+        if (acronymTitle) {
+          const valueHTML = dataAttribute ? `<abbr data-title="${acronymTitle}">${value}</abbr>` : `<abbr title="${acronymTitle}">${value}</abbr>`;
+
+          return {
+            type: 'html',
+            value: valueHTML,
+          };
+        }
+
+        return {
+          type: 'text',
+          value,
+        };
       });
 
       parent.children.splice(index, 1, ...newNodes);


### PR DESCRIPTION
To set custom styling for native "title" attribute, unfortunately, impossible. So, was added the ability to set acronym description inside the "data-title" attribute, which can be easily styled with CSS.