### PR TITLE
Add support for Gatsby v4, change output config

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "typescript": "^4.4.4"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0 || ^3.0.0"
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "files": [
     "dist/**/*"


### PR DESCRIPTION
Hi, @pedrolamas 👋 Here's a small set of changes to make it work in Gatsby v4. Review it, please.

The changelog:
- Added Gatsby v4 to the peer dependencies (removes the warning on the build step)
- Changed TypeScript Compiler config output to the root folder. I am not sure why exactly but it stopped working, the "main" property didn't help there, and as I checked other plugins they just use the root folder for it. Tested on Node v14.18.1 (minimal for Gatsby v4 is `>=14.15.0`).

And please, as a part of the [Hacktoberfest](https://hacktoberfest.digitalocean.com/) OSS initiative, I wanted to ask you to add the label `hacktoberfest-accepted` if that PR will be accepted and merged, thanks!